### PR TITLE
add support for php 8

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -3,20 +3,20 @@ $finder = PhpCsFixer\Finder::create()
     ->in('src')
     ->in('tests')
 ;
-return PhpCsFixer\Config::create()
-    ->setRules(array(
+$config = new PhpCsFixer\Config();
+return $config->setRules(array(
         '@Symfony' => true,
         '@Symfony:risky' => true,
         // override some Symfony rules
-        'blank_line_before_return' => false,
+        'blank_line_before_statement' => false,
         'cast_spaces' => false,
         'concat_space' => array('spacing' => 'one'),
-        'is_null' => array('use_yoda_style' => false),
+        'yoda_style' => false,
         'no_singleline_whitespace_before_semicolons' => false,
         'phpdoc_align' => false,
         'phpdoc_separation' => false,
         'php_unit_fqcn_annotation' => false,
-        'pre_increment' => false,
+        'increment_style' => false,
         // additional rules
         'array_syntax' => array('syntax' => 'short'),
         'general_phpdoc_annotation_remove' => array('annotations' => array('@author', '@inheritdoc')),

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,30 +11,26 @@ env:
 
 matrix:
     include:
-      - php: 5.5
-        env: COMPOSER_ARGS=""
-      - php: 5.6
-        env: COMPOSER_ARGS=""
-      - php: 7.0
-        env: COMPOSER_ARGS=""
       - php: 7.1
         env: COMPOSER_ARGS=""
       - php: 7.2
         env: COMPOSER_ARGS=""
       - php: 7.3
         env: COMPOSER_ARGS="" WITH_CS="true"
+      - php: 7.4
+        env: COMPOSER_ARGS=""
+      - php: 8.0
+        env: COMPOSER_ARGS=""
 
-      - php: 5.5
-        env: COMPOSER_ARGS="--prefer-lowest"
-      - php: 5.6
-        env: COMPOSER_ARGS="--prefer-lowest"
-      - php: 7.0
-        env: COMPOSER_ARGS="--prefer-lowest"
       - php: 7.1
         env: COMPOSER_ARGS="--prefer-lowest"
       - php: 7.2
         env: COMPOSER_ARGS="--prefer-lowest"
       - php: 7.3
+        env: COMPOSER_ARGS="--prefer-lowest"
+      - php: 7.4
+        env: COMPOSER_ARGS="--prefer-lowest"
+      - php: 8.0
         env: COMPOSER_ARGS="--prefer-lowest"
 
 cache:
@@ -50,4 +46,4 @@ before_script:
 
 script:
     - vendor/bin/phpunit
-    - if [[ "$WITH_CS" == "true" ]]; then vendor/bin/php-cs-fixer fix --config=.php_cs -v --dry-run --stop-on-violation --using-cache=no --path-mode=intersection "${COMMIT_SCA_FILES[@]}"; fi
+    - if [[ "$WITH_CS" == "true" ]]; then vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php -v --dry-run --stop-on-violation --using-cache=no --path-mode=intersection "${COMMIT_SCA_FILES[@]}"; fi

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
         "friendsofphp/php-cs-fixer": "^3.0",
         "phpunit/phpunit": "7.5 | ^8.5 | ^9.5",
         "sebastian/comparator": "^3.0 | ^4.0",
-        "misterion/ko-process": "^0.5.3",
         "symfony/stopwatch": "^4.4 | ^5.2"
     },
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -4,15 +4,15 @@
     "keywords": ["rate limiter", "rate limiting", "rate limit", "brute force protection", "leaky bucket", "token bucket", "threshold", "throttle", "security", "dos protection", "brute-force", "bruteforce"],
     "type": "library",
     "require": {
-        "php": "^5.5 | ^7.0",
+        "php": "^7.1 | ^8.0",
         "predis/predis": "^1.1"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.2",
-        "phpunit/phpunit": "^4.8.36",
-        "sebastian/comparator": "^1.2.4",
+        "friendsofphp/php-cs-fixer": "^3.0",
+        "phpunit/phpunit": "7.5 | ^8.5 | ^9.5",
+        "sebastian/comparator": "^3.0 | ^4.0",
         "misterion/ko-process": "^0.5.3",
-        "symfony/stopwatch": "^3.2"
+        "symfony/stopwatch": "^4.4 | ^5.2"
     },
     "license": "MIT",
     "authors": [

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
-FROM php:7
+FROM php:8
 
-ENV PHPREDIS_VERSION 3.0.0
+ENV PHPREDIS_VERSION 5.3.4
 
 RUN mkdir -p /usr/src/php/ext/redis \
     && curl -L https://github.com/phpredis/phpredis/archive/$PHPREDIS_VERSION.tar.gz | tar xvz -C /usr/src/php/ext/redis --strip 1 \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 services:
   php:
     container_name: gentle_force_test_php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit colors="true" bootstrap="vendor/autoload.php">
+<phpunit colors="true" verbose="true" bootstrap="vendor/autoload.php">
     <testsuites>
-        <testsuite>
+        <testsuite name="gentle force tests" >
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/src/InMemory/InMemoryThrottler.php
+++ b/src/InMemory/InMemoryThrottler.php
@@ -68,7 +68,7 @@ class InMemoryThrottler implements ThrottlerInterface
             throw new RateLimitReachedException($validAfter);
         }
 
-        $minUsagesAvailable = INF;
+        $minUsagesAvailable = \INF;
         foreach ($totals as $subKey => $total) {
             $this->storage[$key][$subKey] = $now + $total;
             $minUsagesAvailable = min($minUsagesAvailable, $usagesAvailable[$subKey]);

--- a/tests/Functional/Forker.php
+++ b/tests/Functional/Forker.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Maba\GentleForce\Tests\Functional;
+
+/**
+ * A simple interfacing for forking and returning information from N workers.
+ */
+class Forker
+{
+    /**
+     * Forks the process count($things) times and executes the callback on each
+     * entry in $things, all in parallel.  Collects the return values from each
+     * callback and returns them.
+     *
+     * $things:   An array of anything you want, one process will be created for
+     *            each entry.
+     *
+     * $callback: Function to call for each worker. This function should do the
+     *            body of the work, return the results, and has a signature like
+     *            this: function ($key, $value) {}
+     *
+     * returns:   An array with the same keys as $things but with the results of
+     *            each callback as the value.
+     *
+     * Example:
+     *    $results = Forker::map($things, function ($index, $thing) {
+     *       // Some expensive operation
+     *       return calculateNewThing($thing);
+     *    });
+     * @param mixed $things
+     * @param mixed $callback
+     */
+    public static function map($things, $callback)
+    {
+        $outputStrings = self::mapStream(
+            $things,
+            function ($key, $value, $stream) use ($callback) {
+                $data = $callback($key, $value);
+                fwrite($stream, serialize($data));
+            }
+        );
+
+        $results = [];
+        foreach ($outputStrings as $key => $output) {
+            if ($output === null || $output === '') {
+                $results[$key] = null;
+            } else {
+                $results[$key] = unserialize($output);
+            }
+        }
+        return $results;
+    }
+
+    /**
+     * Forks the process count($things) times and executes the callback on each
+     * entry in $things, all in parallel. Passes a stream to each callback and
+     * collects and returns the string output from each stream.
+     * @param mixed $things
+     * @param mixed $callback
+     */
+    protected static function mapStream($things, $callback)
+    {
+        $children = [];
+
+        foreach ($things as $key => $value) {
+            $info = self::fork();
+            if ($info['parent']) {
+                $children[$key] = $info;
+            } else {
+                $callback($key, $value, $info['stream']);
+                fclose($info['stream']);
+                exit;
+            }
+        }
+
+        return self::getChildrenOutput($children);
+    }
+
+    protected static function fork()
+    {
+        $results = [];
+        $sockets = stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+        $pid = pcntl_fork();
+
+        if ($pid === -1) {
+            exit('Could not fork');
+        } elseif ($pid) {
+            /* parent */
+            fclose($sockets[1]);
+            $results = [
+             'stream' => $sockets[0],
+             'parent' => true,
+          ];
+        } else {
+            /* child */
+            fclose($sockets[0]);
+            $results = [
+             'stream' => $sockets[1],
+             'parent' => false,
+          ];
+        }
+
+        return $results;
+    }
+
+    protected static function getChildrenOutput($children)
+    {
+        $output = [];
+        foreach ($children as $i => $child) {
+            $output[$i] = stream_get_contents($child['stream']);
+        }
+        return $output;
+    }
+}

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -7,17 +7,17 @@ use Maba\GentleForce\RateLimit\UsageRateLimit;
 use Maba\GentleForce\RateLimitProvider;
 use Maba\GentleForce\Throttler;
 use Maba\GentleForce\ThrottlerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Predis\Client;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Component\Stopwatch\StopwatchEvent;
 
 class FunctionalTest extends TestCase
 {
-    const USE_CASE_KEY = 'use_case_key';
-    const ID = 'user1';
-    const ANOTHER_ID = 'user2';
-    const ERROR_CORRECTION_PERIOD_MS = 60;
+    public const USE_CASE_KEY = 'use_case_key';
+    public const ID = 'user1';
+    public const ANOTHER_ID = 'user2';
+    public const ERROR_CORRECTION_PERIOD_MS = 60;
 
     /**
      * @var ThrottlerInterface

--- a/tests/Functional/RaceConditionsTest.php
+++ b/tests/Functional/RaceConditionsTest.php
@@ -9,15 +9,15 @@ use Maba\GentleForce\RateLimit\UsageRateLimit;
 use Maba\GentleForce\RateLimitProvider;
 use Maba\GentleForce\Throttler;
 use Maba\GentleForce\ThrottlerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Predis\Client;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Component\Stopwatch\StopwatchEvent;
 
 class RaceConditionsTest extends TestCase
 {
-    const USE_CASE_KEY = 'use_case_key';
-    const ID = 'user1';
+    public const USE_CASE_KEY = 'use_case_key';
+    public const ID = 'user1';
 
     /**
      * @var ThrottlerInterface
@@ -57,7 +57,7 @@ class RaceConditionsTest extends TestCase
         $manager->wait();
 
         $totalCount = 0;
-        for ($i = 0; $i < count($memory); $i++) {
+        for ($i = 0; $i < \count($memory); $i++) {
             $totalCount += $memory[$i];
         }
 

--- a/tests/RateLimit/BucketRateLimitTest.php
+++ b/tests/RateLimit/BucketRateLimitTest.php
@@ -3,7 +3,7 @@
 namespace Maba\GentleForce\Tests\RateLimit;
 
 use Maba\GentleForce\RateLimit\BucketRateLimit;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class BucketRateLimitTest extends TestCase
 {

--- a/tests/RateLimit/UsageRateLimitTest.php
+++ b/tests/RateLimit/UsageRateLimitTest.php
@@ -4,7 +4,7 @@ namespace Maba\GentleForce\Tests\RateLimit;
 
 use InvalidArgumentException;
 use Maba\GentleForce\RateLimit\UsageRateLimit;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class UsageRateLimitTest extends TestCase
 {
@@ -97,21 +97,19 @@ class UsageRateLimitTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testWithBucketedPeriodAndUsages()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $usageRateLimit = new UsageRateLimit(1, 1);
         $usageRateLimit->setBucketedPeriod(1);
         $usageRateLimit->setBucketedUsages(1);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testWithBucketedUsagesAndPeriod()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $usageRateLimit = new UsageRateLimit(1, 1);
         $usageRateLimit->setBucketedUsages(1);
         $usageRateLimit->setBucketedPeriod(1);

--- a/tests/Redis/Result/CheckAndIncreaseResultTest.php
+++ b/tests/Redis/Result/CheckAndIncreaseResultTest.php
@@ -3,7 +3,7 @@
 namespace Maba\GentleForce\Tests\Redis\Result;
 
 use Maba\GentleForce\Redis\Result\CheckAndIncreaseResult;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class CheckAndIncreaseResultTest extends TestCase
 {


### PR DESCRIPTION
PHP Unit 4.8 is not compatible with php 8, so I add to update it as well. 

There is something wrong in the RaceConditionsTest with misterion/ko-process/src/Ko/SharedMemory,
I have the following error:

shm_get_var(): Variable key 0 doesn't exist

Some thought about that:
- maybe there is something different to do to enable shm in php8 ? 
- Maybe we can try to use PThread instead ?
