### PR TITLE
Improve Dockerfile layers and image building

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,9 +5,7 @@ ENV PHPREDIS_VERSION 5.3.4
 RUN mkdir -p /usr/src/php/ext/redis \
     && curl -L https://github.com/phpredis/phpredis/archive/$PHPREDIS_VERSION.tar.gz | tar xvz -C /usr/src/php/ext/redis --strip 1 \
     && echo 'redis' >> /usr/src/php-available-exts \
-    && docker-php-ext-install redis
-
-RUN docker-php-ext-install pcntl
-RUN docker-php-ext-install posix
-RUN docker-php-ext-install sysvsem
-RUN docker-php-ext-install sysvshm
+    && docker-php-ext-install redis \
+    && docker-php-ext-install pcntl \
+    && docker-php-ext-install sysvsem \
+    && docker-php-ext-install sysvshm


### PR DESCRIPTION
# Changed log

- To reduce the Docker image layers, using the `RUN` command once instead.

Here is the reference about above issue: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers

- When building the Docker image, it seems that the `posix` extension has been already loaded.
I think the `docker-php-ext-install posix` command can be removed. The related warning message is as follows:

```
........
See any operating system documentation about shared libraries for
more information, such as the ld(1) and ld.so(8) manual pages.
----------------------------------------------------------------------

Build complete.
Don't forget to run 'make test'.

Installing shared extensions:     /usr/local/lib/php/extensions/no-debug-non-zts-20200930/

warning: posix (posix.so) is already loaded!
........
```